### PR TITLE
Fixed bathymetry fetch and fixed function calls in setrun.py

### DIFF
--- a/gulf/bathy/get_bathy.py
+++ b/gulf/bathy/get_bathy.py
@@ -5,7 +5,7 @@
 import sys
 import os
 
-import clawpack.geoclaw.util as util
+import clawpack.clawutil.data as data
 
 if __name__ == "__main__":
 
@@ -21,4 +21,4 @@ if __name__ == "__main__":
             "https://dl.dropboxusercontent.com/u/8449354/bathy/NewOrleans_3s.tt3.tar.bz2"]
 
     for url in urls:
-        util.get_remote_file(url, output_dir=output_dir)
+        data.get_remote_file(url, output_dir=output_dir)

--- a/gulf/ike/setrun.py
+++ b/gulf/ike/setrun.py
@@ -12,8 +12,6 @@ import datetime
 
 import numpy as np
 
-# import clawpack.geoclaw.surge.data as surge
-
 # Need to adjust the date a bit due to weirdness with leap year (I think)
 ike_landfall = datetime.datetime(2008,9,13 - 1,7) - datetime.datetime(2008,1,1,0)
 
@@ -478,7 +476,7 @@ def setgeo(rundata):
     if os.environ.has_key("DATA_PATH"):
         topo_path = os.path.join(os.environ["DATA_PATH"], "topography", "gulf")
     else:
-        topo_path = os.getcwd()
+        topo_path = os.path.join(os.getcwd(),'../bathy/')
 
     topo_data.topofiles.append([3, 1, 5, rundata.clawdata.t0, 
                                          rundata.clawdata.tfinal, 
@@ -510,9 +508,6 @@ def setgeo(rundata):
     # for fixed grids append lines of the form
     # [t1,t2,noutput,x1,x2,y1,y2,xpoints,ypoints,\
     #  ioutarrivaltimes,ioutsurfacemax]
-
-    set_storm(rundata)
-    set_friction(rundata)
 
     return rundata
     # end of function setgeo
@@ -547,7 +542,7 @@ def set_storm(rundata):
     # Storm type 2 - Idealized storm track
     data.storm_file = os.path.expandvars(os.path.join(os.getcwd(),'ike.storm'))
 
-    return data
+    return rundata
 
 
 def set_friction(rundata):
@@ -569,7 +564,7 @@ def set_friction(rundata):
                                   [np.infty,-10.0,-200.0,-np.infty],
                                   [0.030, 0.012, 0.022]])
 
-    return data
+    return rundata
 
 
 if __name__ == '__main__':
@@ -579,5 +574,7 @@ if __name__ == '__main__':
         rundata = setrun(sys.argv[1])
     else:
         rundata = setrun()
+    rundata = set_storm(rundata)
+    rundata = set_friction(rundata)
 
     rundata.write()


### PR DESCRIPTION
Made a few minor changes needed to run the Ike case.
 
In get_bathy.py:
- get_remote_file() wasn't in module clawpack.geoclaw.util but was in clawpack.clawutil.data, so I changed that.

In setrun.py:
- Removed a module import which isn't needed and causes an error
- setrun.py was looking for the bathymetry files in the wrong place (in the CWD/ instead of CWD/../bathy/), so I wrote a quick workaround.
- set_storm() and set_friction() weren't properly being called so I fixed that.